### PR TITLE
修复音频反审问题

### DIFF
--- a/model/Sound.js
+++ b/model/Sound.js
@@ -53,7 +53,9 @@ class Sound {
             }
         }
         let set = R.join(",", R.map((condition) => `\`${condition.key}\` = "${condition.value}"`, conditions));
-        let update_sql = `UPDATE m_sound SET ${set}, \`checked\` = ${checked}, \`duration\` = ${this.duration} WHERE id = ${this.id}`;
+        // FIXME: 音频存在重复转码的 BUG，此处添加不修改状态被改动的记录的条件解决“反审”问题，之后需要修复重复转码问题
+        let update_sql = `UPDATE m_sound SET ${set}, \`checked\` = ${checked}, \`duration\` = ${this.duration}
+            WHERE id = ${this.id} AND checked = ${this.checked}`;
         await conn.execute(update_sql);
     }
 


### PR DESCRIPTION
- BUG：音频在数据库断开重连时，可能出现重复转码的问题，导致已过审音频状态被重置为待审核
- 修复方式：更改音频状态时，若音频已过审（包含报警），则不更改审核状态