### PR TITLE
修复 Dockerfile 错误

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,5 +9,4 @@ node_modules/
 .runtime/
 config/
 
-package.json
 package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /home/www/transcoding
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories \
     && apk --update --no-cache add ffmpeg
 
-COPY package.json /home/www/transcoding/
+COPY package.json entrypoint.sh ./
 
 RUN npm config set registry https://registry.npm.taobao.org \
     && npm install \
@@ -17,4 +17,4 @@ COPY . .
 
 USER nobody
 
-ENTRYPOINT ["entrypoint.sh"]
+ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
- BUG：Dockerfile 中一些写法存在错误，如写入忽略文件 `.dockerignore` 中的文件不可被复制，`entrypoint.sh` 路径填写错误
- 修复方式：对错误的部分进行修正