### PR TITLE
修复 ping timeout 问题并添加获取任务队列信息接口

### DIFF
--- a/controller/TaskController.js
+++ b/controller/TaskController.js
@@ -36,7 +36,23 @@ function TaskController(router) {
       ctx.body = await compressInfo.getSoundStatus();
     })
 
-    return router;
+  /**
+   * 获取音频转码任务情况
+   */
+  router.post('/get-task-info', async ctx => {
+    let taskList = [];
+    for (let candidate of candidates) {
+      let task = {
+        sound_id: candidate.id,
+        run: candidate.run,
+        time: candidate.time,
+      }
+      taskList.push(task);
+    }
+    ctx.body = taskList;
+  })
+
+  return router;
 }
 
 module.exports = TaskController;

--- a/lib/ControlFlow.js
+++ b/lib/ControlFlow.js
@@ -47,6 +47,8 @@ q.start = async function() {
             }
             free_concurrent -= rows.length;
             q.soundPush(rows);
+        } catch (e) {
+            logger.error(`client 获取转码任务异常：${e.stack || e}`);
         } finally {
             locker.unlock();
         }

--- a/lib/SocketServer.js
+++ b/lib/SocketServer.js
@@ -15,7 +15,10 @@ const socketClients = [];
  * @param port Socket 服务监听的端口号
  */
 socketClients.__proto__.start = function(app, port) {
-  let io = socketIo(app.listen(port));
+  let io = socketIo(app.listen(port), {
+    // pingInterval: 25000,
+    pingTimeout: 30000,  // socket.io 2.2.0 版本之后设置 pingTimeout 值大于 pingInterval 避免 ping timeout 问题
+  });
   this.io = io;
   // 客户端连接到服务端时执行的动作
   io.on('connection', (socket) => {


### PR DESCRIPTION
- 问题描述：在之前的转码服务中，socket.io 包版本为 `v2.1.0`，此版本默认的 `pingTimeout` 参数值为 60000 ms，而目前线上使用的版本为 `v2.3.0`，此版本默认的 `pingTimeout` 参数值为 5000 ms，当 `pingTimeout` 参数值小于 `pingInterval` 值（默认值 25000 ms）时,，可能出现 ping timeout 问题
- 问题参考：https://github.com/socketio/socket.io/issues/2769
- 修复方式：将 `pingTimeout` 参数值设置为 30000ms
- 需求：添加获取任务队列信息接口
